### PR TITLE
restructure installation of bitstream parser

### DIFF
--- a/p1204_3/__init__.py
+++ b/p1204_3/__init__.py
@@ -10,6 +10,7 @@ import itertools
 from p1204_3.utils import *
 from p1204_3.model import P1204BitstreamMode3
 from p1204_3.generic import *
+from p1204_3.videoparser import check_or_install_videoparser
 
 
 def predict_quality(
@@ -75,6 +76,9 @@ def main(_=[]):
     logging.basicConfig(level=logging.DEBUG)
 
     assert_file(a["model"], "model folder is not valid")
+
+    check_or_install_videoparser()
+
     logging.info(f"handle the following videos (# {len(a['video'])}): \n  " + "\n  ".join(a["video"]))
     params = [
         (

--- a/p1204_3/model.py
+++ b/p1204_3/model.py
@@ -239,7 +239,6 @@ class P1204BitstreamMode3:
 
         self.display_res = display_res
 
-        check_or_install_videoparser()
         os.makedirs(temporary_folder, exist_ok=True)
 
         feature_cache = os.path.join(

--- a/p1204_3/videoparser.py
+++ b/p1204_3/videoparser.py
@@ -1,31 +1,37 @@
 #!/usr/bin/env python3
 import os
-import sys
 import logging
 
-from p1204_3.generic import *
-from p1204_3.utils import file_open
+from p1204_3.generic import VIDEOPARSER_REPO
+from p1204_3.utils import run_cmd
 
 
-def run_videoparser(video_seqment_file, output_dir_full_path, skipexisting=True):
+def run_videoparser(video_segment_file, output_dir_full_path, skipexisting=True):
     """
     Run video parser on a video, save report to output_dir_full_path
     """
-    logging.info("run bitstream parser for {}".format(video_seqment_file))
-    report_file_name = (
-        output_dir_full_path + "/" + os.path.splitext(os.path.basename(video_seqment_file))[0] + ".json.bz2"
+    logging.info("run bitstream parser for {}".format(video_segment_file))
+    report_file_name = os.path.join(
+        output_dir_full_path,
+        os.path.splitext(os.path.basename(video_segment_file))[0] + ".json.bz2",
     )
     if skipexisting and os.path.isfile(report_file_name):
         return report_file_name
     this_path = os.path.dirname(os.path.realpath(__file__))
-    cmd = this_path + """/bitstream_mode3_videoparser/parser.sh "{video}" --output "{report}" """.format(
-        video=video_seqment_file, report=report_file_name
+    parser_shellscript = os.path.join(
+        this_path, "bitstream_mode3_videoparser", "parser.sh"
     )
-    ret = os.system(cmd)
-    if ret != 0:
-        logging.error(f"there was something wrong with {video_seqment_file}")
+    cmd = [parser_shellscript, video_segment_file, "--output", report_file_name]
+
+    try:
+        run_cmd(cmd)
+        return report_file_name
+    except Exception as e:
+        logging.error(f"there was something wrong with {video_segment_file}")
         logging.error(f"please check the following command: \n {cmd}")
+        logging.error(f"output: {e}")
         return ""
+
     return report_file_name
 
 
@@ -35,9 +41,13 @@ def check_or_install_videoparser():
     """
     logging.info("check or install video parser")
     this_path = os.path.dirname(os.path.realpath(__file__))
-    videoparser_directory = f"{this_path}/bitstream_mode3_videoparser"
+    videoparser_directory = os.path.join(this_path, "bitstream_mode3_videoparser")
     if os.path.isdir(videoparser_directory):
         logging.info("video parser is checked out")
-        return
-    os.system(f"git clone {VIDEOPARSER_REPO} {videoparser_directory}")
-    os.system(f"{videoparser_directory}/build_and_test.sh")
+    else:
+        logging.info(
+            "video parser is not checked out, will clone it, which may take a minute"
+        )
+        run_cmd(["git", "clone", VIDEOPARSER_REPO, videoparser_directory])
+        logging.info("building the video parser, which may take a while")
+        run_cmd([f"{videoparser_directory}/build_and_test.sh"])


### PR DESCRIPTION
- add a new run_cmd function that properly quotes shell calls
- install the parser up front, not inside the parsing function
- add some logs to inform the user what is going on
- fix typo in "seqment" variable
- clean up imports